### PR TITLE
Fix the ActorSystem handling.

### DIFF
--- a/Sample/src/main/scala/com/github/BambooTuna/LiquidPusher/Main.scala
+++ b/Sample/src/main/scala/com/github/BambooTuna/LiquidPusher/Main.scala
@@ -1,10 +1,12 @@
 package com.github.BambooTuna.LiquidPusher
 
+import akka.actor.ActorSystem
 import com.github.BambooTuna.LiquidPusher.client.LiquidPusher
 import com.github.BambooTuna.LiquidPusher.pusher._
 
 object Main {
   def main(args: Array[String]): Unit = {
+    implicit val actorSystem = ActorSystem("LiquidPusher")
     val pusherOptions = PusherOptions("wss://tap.liquid.com").setAuthorizer(PusherAuthorizer("key", "secret"))
     //val pusherOptions = PusherOptions("wss://tap.liquid.com", Some(PusherAuthorizer("key", "secret")))
     val liquidPusher = new LiquidPusher(pusherOptions)

--- a/src/main/scala/com/github/BambooTuna/LiquidPusher/client/LiquidPusher.scala
+++ b/src/main/scala/com/github/BambooTuna/LiquidPusher/client/LiquidPusher.scala
@@ -1,17 +1,16 @@
 package com.github.BambooTuna.LiquidPusher.client
 
+import akka.actor.ActorSystem
 import com.github.BambooTuna.LiquidPusher.client.LiquidPusherProtocol._
 import com.github.BambooTuna.LiquidPusher.pusher.PusherProtocol._
 import com.github.BambooTuna.LiquidPusher.pusher._
 import com.github.BambooTuna.LiquidPusher.websocket.WebSocket
-
-import pdi.jwt.{JwtAlgorithm, Jwt}
-
+import pdi.jwt.{Jwt, JwtAlgorithm}
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.auto._
 
-class LiquidPusher(pusherOptions: PusherOptions) extends Pusher(pusherOptions) {
+class LiquidPusher(pusherOptions: PusherOptions)(implicit system: ActorSystem) extends Pusher(pusherOptions) {
   override protected val ws: WebSocket = new WebSocket(pusherOptions.host, setListener(this))
 
   private var authResultListenerOption: Option[ChannelListener] = None

--- a/src/main/scala/com/github/BambooTuna/LiquidPusher/pusher/Pusher.scala
+++ b/src/main/scala/com/github/BambooTuna/LiquidPusher/pusher/Pusher.scala
@@ -1,5 +1,6 @@
 package com.github.BambooTuna.LiquidPusher.pusher
 
+import akka.actor.ActorSystem
 import com.github.BambooTuna.LiquidPusher.LogSupport
 import com.github.BambooTuna.LiquidPusher.pusher.PusherProtocol._
 import com.github.BambooTuna.LiquidPusher.websocket.{WebSocket, WebSocketListener}
@@ -7,7 +8,7 @@ import io.circe._
 import io.circe.syntax._
 import io.circe.generic.auto._
 
-class Pusher(pusherOptions: PusherOptions) extends LogSupport {
+class Pusher(pusherOptions: PusherOptions)(implicit system: ActorSystem) extends LogSupport {
   protected var connectionListenerOption: Option[ConnectionListener] = None
   protected var channelListeners: Map[String, ChannelListener] = Map.empty
 

--- a/src/main/scala/com/github/BambooTuna/LiquidPusher/websocket/WebSocket.scala
+++ b/src/main/scala/com/github/BambooTuna/LiquidPusher/websocket/WebSocket.scala
@@ -11,8 +11,7 @@ import akka.{Done, NotUsed}
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-class WebSocket(val host: String, val wsListener: WebSocketListener) {
-  implicit val system = ActorSystem()
+class WebSocket(val host: String, val wsListener: WebSocketListener)(implicit system: ActorSystem) {
   implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
@@ -50,10 +49,13 @@ class WebSocket(val host: String, val wsListener: WebSocketListener) {
       case Failure(exception) => wsListener.onError(exception)
     }
   }
+
   def send(data: String): Unit = {
     wsInstance.foreach(_ ! TextMessage.Strict(data))
   }
+
   private def setWsInstance(ws: ActorRef): Unit = {
     wsInstance = Option(ws)
   }
+
 }


### PR DESCRIPTION
In principle, there is only one ActorSystem per application. If an ActoSystem is created for each WebSocket instance, it is very wasteful. Changed to pass ActorSystem from outside.